### PR TITLE
Enable host config in forwarder_agent

### DIFF
--- a/src/cmd/forwarder-agent/app/config.go
+++ b/src/cmd/forwarder-agent/app/config.go
@@ -11,6 +11,7 @@ import (
 // GRPC stores the configuration for the router as a server using a PORT
 // with mTLS certs and as a client.
 type GRPC struct {
+	Host         string   `env:"AGENT_HOST, report"`
 	Port         uint16   `env:"AGENT_PORT, report"`
 	CAFile       string   `env:"AGENT_CA_FILE_PATH, required, report"`
 	CertFile     string   `env:"AGENT_CERT_FILE_PATH, required, report"`
@@ -40,6 +41,7 @@ type Config struct {
 func LoadConfig() Config {
 	cfg := Config{
 		GRPC: GRPC{
+			Host: "127.0.0.1",
 			Port: 3458,
 		},
 	}

--- a/src/cmd/forwarder-agent/app/forwarder_agent.go
+++ b/src/cmd/forwarder-agent/app/forwarder_agent.go
@@ -139,7 +139,7 @@ func (s *ForwarderAgent) Run() {
 	rx := v2.NewReceiver(diode, im, omm)
 
 	s.v2srv = v2.NewServer(
-		fmt.Sprintf("127.0.0.1:%d", s.grpc.Port),
+		fmt.Sprintf("%s:%d", s.grpc.Host, s.grpc.Port),
 		rx,
 		grpc.Creds(serverCreds),
 		grpc.MaxRecvMsgSize(10*1024*1024),


### PR DESCRIPTION
# Description

The change modifies loggr-forwarder-agent so that it can accept connections not only from localhost

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [ ] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
